### PR TITLE
Removed closing tag and whitespace as it was causing headers to go early

### DIFF
--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -1071,6 +1071,3 @@ class Aauth {
  * tamm// already existedleri info yap onlar error değil hacım
  *
  */
-
-?>
-


### PR DESCRIPTION
The whitespace at the end of the library file was causing it to try and send data to the browser. This caused "Warning: headers already sent" errors.
