### PR TITLE
Remove allowed characters from name before alphanumeric test

### DIFF
--- a/application/config/aauth.php
+++ b/application/config/aauth.php
@@ -43,6 +43,9 @@ $config['aauth'] = array(
     // pasword maximum char long (min is 4)
     'max' => 13,
 
+    // non alphanumeric characters that are allowed in a name
+    'valid_chars' => array(' ', '\''),
+
     // it limits login attempts
     'dos_protection' => true,
 

--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -297,7 +297,7 @@ class Aauth {
             $this->error($this->config_vars['pass_invalid']);
             $valid = false;
         }
-        if ($name !='' and !ctype_alnum($name)){
+        if ($name !='' and !ctype_alnum(str_replace($this->config_vars['valid_chars'], '', $name))){
             $this->error($this->config_vars['name_invalid']);
             $valid = false;
         }


### PR DESCRIPTION
Currently the name only allows alphanumeric.

This code now checks for accepted characters such as spaces and apostrophes and removes them from the string being tested for alphanumeric.

Now allows names such as:
"John Smith"
"Jim O'Neil"
