### PR TITLE
Update Aauth.php

### DIFF
--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -100,8 +100,16 @@ class Aauth {
 
         $this->CI->input->set_cookie($cookie);
 
-        // verification
-        if( !valid_email($email) or !ctype_alnum($pass) or strlen($pass) < 5 or
+ 
+        /*
+        *
+        * User Verification
+        *
+        * Removed or !ctype_alnum($pass) from the IF statement
+        * It was causing issues with special characters in passwords
+        * and returning false even if the password matches.
+        */
+        if( !valid_email($email) or strlen($pass) < 5 or
             strlen($pass) > $this->config_vars['max'] )
         {
             $this->error($this->config_vars['wrong']);


### PR DESCRIPTION
When trying to login a user with a special password for example: Password@123, the script would return an error saying the password was wrong.

I removed "or !ctype_alnum($pass)" from the login section which allows users to login and register with html chars in their passwords.
