### PR TITLE
By default admin group have access to all permissions

### DIFF
--- a/application/libraries/Aauth.php
+++ b/application/libraries/Aauth.php
@@ -1642,6 +1642,10 @@ class Aauth {
 
 		// if group par is given
 		if($group_par != FALSE){
+			
+			// if group is admin group, as admin group has access to all permissions
+			if (strcasecmp($group_par, $this->config_vars['admin_group']) == 0)
+			{return TRUE;}
 
 			$subgroup_ids = $this->get_subgroups($group_par);
 			$group_par = $this->get_group_id($group_par);


### PR DESCRIPTION
As admin user has access to all permissions, so admin group also has the same access. so needed to check if $group_par is admin or not